### PR TITLE
chore: update PHP and Laravel version requirements in composer.json a…

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require --dev "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,6 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
-  pull_request:
 
 jobs:
   test:
@@ -64,7 +63,8 @@ jobs:
       - name: Install dependencies
         run: |
           composer require --dev "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          # --no-audit: Laravel 10 / PHPUnit 10.5.x в матрице помечены advisory; для проверки совместимости пакета это допустимо
+          # Матрица с Laravel 10 / старым PHPUnit: Packagist advisory блокирует разрешение, пока audit.block-insecure=true
+          composer config audit.block-insecure false
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-audit
 
       - name: List Installed Dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,7 +64,8 @@ jobs:
       - name: Install dependencies
         run: |
           composer require --dev "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          # --no-audit: Laravel 10 / PHPUnit 10.5.x в матрице помечены advisory; для проверки совместимости пакета это допустимо
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-audit
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,7 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
+  pull_request:
 
 jobs:
   test:
@@ -16,10 +17,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4, 8.3, 8.1]
-        laravel: [12.*, 11.*, 10.*]
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
+        laravel: [13.*, 12.*, 11.*, 10.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
@@ -29,10 +32,16 @@ jobs:
         exclude:
           - laravel: 10.*
             php: 8.4
+          - laravel: 10.*
+            php: 8.5
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
@@ -71,15 +80,21 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4, 8.3, 8.2, 8.1]
-        laravel: [12, 11, 10]
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
+        laravel: [13, 12, 11, 10]
         exclude:
           - laravel: 10
             php: 8.4
+          - laravel: 10
+            php: 8.5
           - laravel: 11
             php: 8.1
           - laravel: 12
             php: 8.1
+          - laravel: 13
+            php: 8.1
+          - laravel: 13
+            php: 8.2
     name: "Laravel ${{ matrix.laravel }} on PHP${{ matrix.php }}"
     steps:
       - name: Setup PHP

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         }
     ],
     "require": {
-        "php": "^8.1||^8.2||^8.3||^8.4",
+        "php": "^8.1||^8.2||^8.3||^8.4||^8.5",
         "spatie/laravel-package-tools": "^1.92",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.9||^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
-        "pestphp/pest": "^3.0||^2.0",
-        "pestphp/pest-plugin-arch": "^3.0||^2.0",
-        "pestphp/pest-plugin-laravel": "^3.0||^2.0",
+        "orchestra/testbench": "^11.0||^10.0||^9.0||^8.0",
+        "pestphp/pest": "^4.0||^3.0||^2.0",
+        "pestphp/pest-plugin-arch": "^4.0||^3.0||^2.0",
+        "pestphp/pest-plugin-laravel": "^4.0||^3.0||^2.0",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0",
@@ -45,16 +45,33 @@
     "autoload-dev": {
         "psr-4": {
             "GoCPA\\SpaceHealthcheck\\Tests\\": "tests/",
-            "Workbench\\App\\": "workbench/app/"
+            "Workbench\\App\\": "workbench/app/",
+            "Workbench\\Database\\Factories\\": "workbench/database/factories/",
+            "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
         }
     },
     "scripts": {
-        "post-autoload-dump": "@composer run prepare",
+        "post-autoload-dump": [
+            "@clear",
+            "@prepare",
+            "@composer run prepare"
+        ],
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/pint"
+        "format": "vendor/bin/pint",
+        "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
+        "build": "@php vendor/bin/testbench workbench:build --ansi",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "@build",
+            "@php vendor/bin/testbench serve --ansi"
+        ],
+        "lint": [
+            "@php vendor/bin/pint --ansi",
+            "@php vendor/bin/phpstan analyse --verbose --ansi"
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,13 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "orchestra/testbench": "^11.0||^10.0||^9.0||^8.0",
-        "pestphp/pest": "^4.0||^3.0||^2.0",
+        "pestphp/pest": "^4.0||^3.0||^2.36.0",
         "pestphp/pest-plugin-arch": "^4.0||^3.0||^2.0",
-        "pestphp/pest-plugin-laravel": "^4.0||^3.0||^2.0",
+        "pestphp/pest-plugin-laravel": "^4.0||^3.0||^2.4",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0",
+        "phpunit/phpunit": "10.5.36|^11.5.50|^12.5.8|^13.0.3",
         "spatie/laravel-health": "^1.32"
     },
     "suggest": {


### PR DESCRIPTION
…nd CI workflows

- Updated PHP requirement to include version 8.5 in composer.json.
- Expanded Laravel contract support to include version 13.0.
- Adjusted development dependencies for Orchestra Testbench and Pest to support newer versions.
- Modified GitHub Actions workflows to use PHP 8.5 and updated Laravel versions in test matrices.